### PR TITLE
Adds a "does not work in space" tooltip entry to ore wand

### DIFF
--- a/src/main/java/com/encraft/dz/items/ItemOreFinderTool.java
+++ b/src/main/java/com/encraft/dz/items/ItemOreFinderTool.java
@@ -238,6 +238,11 @@ public class ItemOreFinderTool extends Item {
             list.add("SHIFT+RIGHT CLICK on ground to open inventory");
             list.add("You can only use 1 finder at a time");
             list.add("Search radius X, Z: "+ ConfigHandler.xzAreaRadius +" Y: "+ConfigHandler.yAreaRadius);
+
+            if (!ConfigHandler.aEnableEverywhere) {
+                list.add("** DOES NOT WORK IN SPACE! **");
+                list.add("Overworld, Nether, Twilight Forest only");
+            }
         }
     }
 


### PR DESCRIPTION
Given that folks still get tripped up by this, I figure making it explicit in the tooltip might save some grief.