### PR TITLE
Fix voiding when shift clicking item in wand whilst inventory is full

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.23:dev')
-    implementation('com.github.GTNewHorizons:VisualProspecting:1.2.1:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.79:dev')
+    implementation('com.github.GTNewHorizons:VisualProspecting:1.2.10:dev')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId = GRADLETOKEN_MODID
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName = GRADLETOKEN_MODNAME
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName = GRADLETOKEN_GROUPNAME
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ disableCheckstyle = true
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.15'
 }
 
 

--- a/src/main/java/com/encraft/dz/container/ContainerBuildingKit.java
+++ b/src/main/java/com/encraft/dz/container/ContainerBuildingKit.java
@@ -50,24 +50,25 @@ public class ContainerBuildingKit extends Container {
             ((Slot) this.inventorySlots.get(par2)).putStack(toMove);
         } else {
             boolean canMerge = false;
-            ItemStack toMove = ((SlotItemInv) this.inventorySlots.get(0)).getStack();
+            SlotItemInv fromSlot = (SlotItemInv) this.inventorySlots.get(0);
+            ItemStack toMove = fromSlot.getStack();
             if (toMove == null) return null;
             for (int i = 1; i < this.inventorySlots.size(); i++) {
-                if ((GT_Utility.areStacksEqual(
-                        ((SlotItemInv) this.inventorySlots.get(0)).getStack(),
-                        ((Slot) this.inventorySlots.get(i)).getStack())
-                        && ((Slot) this.inventorySlots.get(i)).getStack().stackSize
-                                < ((Slot) this.inventorySlots.get(i)).getStack().getMaxStackSize())) {
-                    ((Slot) this.inventorySlots.get(i)).getStack().stackSize++;
-                    ((SlotItemInv) this.inventorySlots.get(0)).putStack(null);
+                Slot toSlot = (Slot) this.inventorySlots.get(i);
+                ItemStack toPlace = toSlot.getStack();
+
+                if (GT_Utility.areStacksEqual(toMove, toPlace) && toPlace.stackSize < toPlace.getMaxStackSize()) {
+                    toPlace.stackSize++;
+                    fromSlot.putStack(null);
                     canMerge = true;
                     break;
                 }
             }
             for (int i = 1; i < this.inventorySlots.size(); i++) {
-                if (!canMerge && (!((Slot) this.inventorySlots.get(i)).getHasStack())) {
-                    ((SlotItemInv) this.inventorySlots.get(0)).putStack(null);
-                    ((Slot) this.inventorySlots.get(i)).putStack(toMove);
+                Slot toSlot = ((Slot) this.inventorySlots.get(i));
+                if (!canMerge && !toSlot.getHasStack()) {
+                    fromSlot.putStack(null);
+                    toSlot.putStack(toMove);
                     break;
                 }
             }

--- a/src/main/java/com/encraft/dz/container/ContainerBuildingKit.java
+++ b/src/main/java/com/encraft/dz/container/ContainerBuildingKit.java
@@ -66,7 +66,7 @@ public class ContainerBuildingKit extends Container {
             }
             for (int i = 1; i < this.inventorySlots.size(); i++) {
                 Slot toSlot = ((Slot) this.inventorySlots.get(i));
-                if (!canMerge && !toSlot.getHasStack()) {
+                if (!canMerge && toSlot.getStack() == null) {
                     fromSlot.putStack(null);
                     toSlot.putStack(toMove);
                     break;


### PR DESCRIPTION
It tries to place the ore in the same slot as the ore wand since that is a locked slot where `getHasStack()` always returns [false](https://github.com/GTNewHorizons/IFU/blob/fb06e02b0b273c6b472814c117d056978726c239/src/main/java/com/encraft/dz/container/SlotBlockedItemInv.java#L32).

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15619