### PR TITLE
Make ore vein discovery range configurable

### DIFF
--- a/src/main/java/com/encraft/dz/handlers/ConfigHandler.java
+++ b/src/main/java/com/encraft/dz/handlers/ConfigHandler.java
@@ -15,6 +15,7 @@ public class ConfigHandler {
 
     public static boolean wandSound = true;
     public static int xzAreaRadius = 5;
+    public static int oreVeinDiscoveryRange = 24;
     public static int yAreaRadius = 60;
     public static String[] blocklist = {};
     public static String[] materialBlocklist = {};
@@ -39,6 +40,13 @@ public class ConfigHandler {
                 1,
                 16,
                 " change scanning radius from player");
+        oreVeinDiscoveryRange = cfg.getInt(
+                "Ore vein discovery range",
+                Configuration.CATEGORY_GENERAL,
+                oreVeinDiscoveryRange,
+                xzAreaRadius,
+                64,
+                "Block radius (square, centered on the player) for revealing ore veins of the type just found. ");
         yAreaRadius = cfg.getInt(
                 "Y Area radius",
                 Configuration.CATEGORY_GENERAL,

--- a/src/main/java/com/encraft/dz/items/ItemOreFinderTool.java
+++ b/src/main/java/com/encraft/dz/items/ItemOreFinderTool.java
@@ -159,7 +159,7 @@ public class ItemOreFinderTool extends Item {
 
     private void prospectForVeins(World world, EntityPlayerMP player, int x1, int z1, IOreMaterial ore) {
         List<OreVeinPosition> veins = VisualProspecting_API.LogicalServer
-                .prospectOreVeinsWithinRadius(world.provider.dimensionId, x1, z1, ConfigHandler.xzAreaRadius + 1)
+                .prospectOreVeinsWithinRadius(world.provider.dimensionId, x1, z1, ConfigHandler.oreVeinDiscoveryRange)
                 .stream().filter(it -> it.veinType.containsOre(ore)).collect(Collectors.toList());
 
         VisualProspecting_API.LogicalServer.sendProspectionResultsToClient(player, veins, Collections.emptyList());


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25585

Issue of dev vote at: https://discord.com/channels/181078474394566657/1438902363774779452/1521566131683594281

Default of 24 blocks around player make it basically touch a 3x3 chunks area around the player. Should hit side veins again.
Old default value was 52.

Since this is now a conf if the default end up not ok it can be easily changed in the modpack: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/master/config/ifu.cfg
It also allow player edit range should they wish for it.
